### PR TITLE
Might not be an issue. Test for it passed.

### DIFF
--- a/src/Nancy.Patch.Tests/PatchExecutorTests.cs
+++ b/src/Nancy.Patch.Tests/PatchExecutorTests.cs
@@ -100,5 +100,27 @@ namespace Nancy.Patch.Tests
             Assert.AreNotEqual(from.Description, to.Description);
             Assert.AreNotEqual(from.ShortDescription, to.ShortDescription);
         }
+
+        [Test]
+        public void Patch_Should_Allow_Nullifying_Existing_Properties()
+        {
+            var from = new TestModel
+            {
+                Name = string.Empty
+            };
+            var to = new TestModel
+            {
+                Name = "Test"
+            };
+            var propertiesToMerge = new[]
+            {
+                "name"
+            };
+
+            var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(from.Name, to.Name);
+        }
     }
 }


### PR DESCRIPTION
#3 turns out to be a non-issue. The error was to do with the configuration of a JsonSerializer on the client side that was just omitting nulls from the request.

Added a test just to make sure that it **does actually work**
