### PR TITLE
Ignore read-only properties

### DIFF
--- a/src/Nancy.Patch.Tests/Mocks/TestModel.cs
+++ b/src/Nancy.Patch.Tests/Mocks/TestModel.cs
@@ -6,5 +6,10 @@
         public string Name { get; set; }
         public string Description { get; set; }
         public string ShortDescription { get; set; }
+
+        public string ReadOnlyName
+        {
+            get { return "Test"; }
+        }
     }
 }

--- a/src/Nancy.Patch.Tests/PatchExecutorTests.cs
+++ b/src/Nancy.Patch.Tests/PatchExecutorTests.cs
@@ -100,5 +100,28 @@ namespace Nancy.Patch.Tests
             Assert.AreNotEqual(from.Description, to.Description);
             Assert.AreNotEqual(from.ShortDescription, to.ShortDescription);
         }
+
+        [Test]
+        public void Patch_Should_Ignore_Read_Only_Property()
+        {
+            var from = new TestModel
+            {
+                Name = "Original"
+            };
+            var to = new TestModel()
+            {
+                Name = "To"
+            };
+            var propertiesToMerge = new[]
+            {
+                "name",
+                "readonlyname"
+            };
+
+            var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(from.Name, to.Name);
+        }
     }
 }

--- a/src/Nancy.Patch/PatchExecutor.cs
+++ b/src/Nancy.Patch/PatchExecutor.cs
@@ -31,6 +31,9 @@ namespace Nancy.Patch
             foreach (var propertyToMerge in propertiesToMerge)
             {
                 var propertyInfo = type.GetProperty(propertyToMerge, bindingFlags);
+                if (propertyInfo == null || !propertyInfo.CanWrite)
+                    continue;
+
                 var newValue = propertyInfo.GetValue(from, null);
 
                 propertyInfo.SetValue(to, newValue, null);


### PR DESCRIPTION
Fixed issue where property merge would fail if the property is readonly.  It now silently ignores the property.
