### PR TITLE
Hotfix/invalid property handling

### DIFF
--- a/src/Nancy.Patch.Tests/PatchExecutorTests.cs
+++ b/src/Nancy.Patch.Tests/PatchExecutorTests.cs
@@ -134,50 +134,50 @@ namespace Nancy.Patch.Tests
             Assert.AreEqual(from.Name, to.Name);
         }
 
-	    [Test]
-	    public void Patch_Given_Property_Not_In_Object_Should_Return_False_With_Message()
-	    {
-			var from = new TestModel
-			{
-				Name = "Original"
-			};
-			var to = new TestModel()
-			{
-				Name = "To"
-			};
-			var propertiesToMerge = new[]
+        [Test]
+        public void Patch_Given_Property_Not_In_Object_Should_Return_False_With_Message()
+        {
+            var from = new TestModel
+            {
+                Name = "Original"
+            };
+            var to = new TestModel()
+            {
+                Name = "To"
+            };
+            var propertiesToMerge = new[]
             {
                 "name",
                 "iamnothere"
             };
 
-			var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
+            var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
 
-			Assert.IsFalse(result);
-			Assert.AreEqual("Could not find writable property: iamnothere", result.Message);
-	    }
+            Assert.IsFalse(result);
+            Assert.AreEqual("Could not find writable property: iamnothere", result.Message);
+        }
 
-	    [Test]
-	    public void Patch_Given_Read_Only_Property_Should_Return_False_With_Message()
-	    {
-			var from = new TestModel
-			{
-				Name = "Original"
-			};
-			var to = new TestModel()
-			{
-				Name = "To"
-			};
-			var propertiesToMerge = new[]
+        [Test]
+        public void Patch_Given_Read_Only_Property_Should_Return_False_With_Message()
+        {
+            var from = new TestModel
+            {
+                Name = "Original"
+            };
+            var to = new TestModel()
+            {
+                Name = "To"
+            };
+            var propertiesToMerge = new[]
             {
                 "name",
                 "readonlyname"
             };
 
-			var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
+            var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
 
-		    Assert.IsFalse(result);
-			Assert.AreEqual("Could not find writable property: readonlyname", result.Message);
-	    }
+            Assert.IsFalse(result);
+            Assert.AreEqual("Could not find writable property: readonlyname", result.Message);
+        }
     }
 }

--- a/src/Nancy.Patch.Tests/PatchExecutorTests.cs
+++ b/src/Nancy.Patch.Tests/PatchExecutorTests.cs
@@ -134,27 +134,50 @@ namespace Nancy.Patch.Tests
             Assert.AreEqual(from.Name, to.Name);
         }
 
-        [Test]
-        public void Patch_Should_Ignore_Read_Only_Property()
-        {
-            var from = new TestModel
+	    [Test]
+	    public void Patch_Given_Property_Not_In_Object_Should_Return_False_With_Message()
+	    {
+			var from = new TestModel
+			{
+				Name = "Original"
+			};
+			var to = new TestModel()
+			{
+				Name = "To"
+			};
+			var propertiesToMerge = new[]
             {
-                Name = "Original"
+                "name",
+                "iamnothere"
             };
-            var to = new TestModel()
-            {
-                Name = "To"
-            };
-            var propertiesToMerge = new[]
+
+			var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
+
+			Assert.IsFalse(result);
+			Assert.AreEqual("Could not find writable property: iamnothere", result.Message);
+	    }
+
+	    [Test]
+	    public void Patch_Given_Read_Only_Property_Should_Return_False_With_Message()
+	    {
+			var from = new TestModel
+			{
+				Name = "Original"
+			};
+			var to = new TestModel()
+			{
+				Name = "To"
+			};
+			var propertiesToMerge = new[]
             {
                 "name",
                 "readonlyname"
             };
 
-            var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
+			var result = new PatchExecutor().Patch(from, to, propertiesToMerge);
 
-            Assert.IsTrue(result);
-            Assert.AreEqual(from.Name, to.Name);
-        }
+		    Assert.IsFalse(result);
+			Assert.AreEqual("Could not find writable property: readonlyname", result.Message);
+	    }
     }
 }

--- a/src/Nancy.Patch/Exceptions/PropertyNotFoundException.cs
+++ b/src/Nancy.Patch/Exceptions/PropertyNotFoundException.cs
@@ -2,14 +2,14 @@
 
 namespace Nancy.Patch.Exceptions
 {
-	internal class PropertyNotFoundException : Exception
-	{
-		public string PropertyName { get; private set; }
+    internal class PropertyNotFoundException : Exception
+    {
+        public string PropertyName { get; private set; }
 
-		public PropertyNotFoundException(string propertyName)
-			: base("Could not find writable property: " + propertyName)
-		{
-			PropertyName = propertyName;
-		}
-	}
+        public PropertyNotFoundException(string propertyName)
+            : base("Could not find writable property: " + propertyName)
+        {
+            PropertyName = propertyName;
+        }
+    }
 }

--- a/src/Nancy.Patch/Exceptions/PropertyNotFoundException.cs
+++ b/src/Nancy.Patch/Exceptions/PropertyNotFoundException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Nancy.Patch.Exceptions
+{
+	internal class PropertyNotFoundException : Exception
+	{
+		public string PropertyName { get; private set; }
+
+		public PropertyNotFoundException(string propertyName)
+			: base("Could not find writable property: " + propertyName)
+		{
+			PropertyName = propertyName;
+		}
+	}
+}

--- a/src/Nancy.Patch/Nancy.Patch.csproj
+++ b/src/Nancy.Patch/Nancy.Patch.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\PropertyNotFoundException.cs" />
     <Compile Include="PatchExecutor.cs" />
     <Compile Include="PatchExtensions.cs" />
     <Compile Include="PatchResult.cs" />

--- a/src/Nancy.Patch/PatchExecutor.cs
+++ b/src/Nancy.Patch/PatchExecutor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Nancy.Patch.Exceptions;
 
 namespace Nancy.Patch
 {
@@ -31,8 +32,9 @@ namespace Nancy.Patch
             foreach (var propertyToMerge in propertiesToMerge)
             {
                 var propertyInfo = type.GetProperty(propertyToMerge, bindingFlags);
-                if (propertyInfo == null || !propertyInfo.CanWrite)
-                    continue;
+
+	            if (propertyInfo == null || !propertyInfo.CanWrite)
+		            throw new PropertyNotFoundException(propertyToMerge);
 
                 var newValue = propertyInfo.GetValue(from, null);
 

--- a/src/Nancy.Patch/PatchExecutor.cs
+++ b/src/Nancy.Patch/PatchExecutor.cs
@@ -33,8 +33,8 @@ namespace Nancy.Patch
             {
                 var propertyInfo = type.GetProperty(propertyToMerge, bindingFlags);
 
-	            if (propertyInfo == null || !propertyInfo.CanWrite)
-		            throw new PropertyNotFoundException(propertyToMerge);
+                if (propertyInfo == null || !propertyInfo.CanWrite)
+                    throw new PropertyNotFoundException(propertyToMerge);
 
                 var newValue = propertyInfo.GetValue(from, null);
 


### PR DESCRIPTION
Instead of just continuing, we should throw to let anyone using this package know that a property has failed to be updated due to the property not being found, or being read-only.
